### PR TITLE
Add repository-gcs plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,3 @@
 FROM opensearchproject/opensearch:2.19.0
 RUN /usr/share/opensearch/bin/opensearch-plugin install --batch repository-s3
+RUN /usr/share/opensearch/bin/opensearch-plugin install --batch repository-gcs 


### PR DESCRIPTION
This is required in order to use service account to access GCP object storage for Opensearch snapshots

Relates to PLAT-1001